### PR TITLE
Add campaign classification hierarchy

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,32 +1,32 @@
-import React, { useState } from 'react';
-import { Retool } from '@tryretool/custom-component-support';
+import React, { useState } from 'react'
+import { Retool } from '@tryretool/custom-component-support'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 type Metrics = {
-  Cost?: number;
-  Revenue?: number;
-  Sessions?: number;
-  Transactions?: number;
-  NewUsers?: number;
-  GA_last_click_revenue?: number;
-  Attributed_Revenue?: number;
-  Revenue_minus_embedded_awareness?: number;
-  embedded_awareness?: number;
-};
+  Cost?: number
+  Revenue?: number
+  Sessions?: number
+  Transactions?: number
+  NewUsers?: number
+  GA_last_click_revenue?: number
+  Attributed_Revenue?: number
+  Revenue_minus_embedded_awareness?: number
+  embedded_awareness?: number
+}
 
 interface CampaignNode {
-  name: string;
-  current: Metrics;
-  prior: Metrics;
-  children?: CampaignNode[];
+  name: string
+  current: Metrics
+  prior: Metrics
+  children?: CampaignNode[]
 }
 
 interface MetricDef {
-  key: keyof Metrics;
-  label: string;
-  digits: number;
-  currency?: boolean;
+  key: keyof Metrics
+  label: string
+  digits: number
+  currency?: boolean
 }
 
 const metricDefs: readonly MetricDef[] = [
@@ -35,16 +35,196 @@ const metricDefs: readonly MetricDef[] = [
   { key: 'Sessions', label: 'Sessions', digits: 0 },
   { key: 'Transactions', label: 'Transactions', digits: 0 },
   { key: 'NewUsers', label: 'New Users', digits: 0 },
-  { key: 'GA_last_click_revenue', label: 'GA Last Click Rev', digits: 2, currency: true },
-  { key: 'Attributed_Revenue', label: 'Attributed Rev', digits: 2, currency: true },
+  {
+    key: 'GA_last_click_revenue',
+    label: 'GA Last Click Rev',
+    digits: 2,
+    currency: true
+  },
+  {
+    key: 'Attributed_Revenue',
+    label: 'Attributed Rev',
+    digits: 2,
+    currency: true
+  },
   {
     key: 'Revenue_minus_embedded_awareness',
     label: 'Rev minus Awareness',
     digits: 2,
     currency: true
   },
-  { key: 'embedded_awareness', label: 'Embedded Awareness', digits: 2, currency: true }
-] as const;
+  {
+    key: 'embedded_awareness',
+    label: 'Embedded Awareness',
+    digits: 2,
+    currency: true
+  }
+] as const
+
+interface Classification {
+  top: string
+  mid: string
+}
+
+const classificationMap: Record<string, Classification> = {
+  'paid social awareness campaign items': {
+    top: 'Social',
+    mid: 'Social Organic Boosting'
+  },
+  'paid social - iris campaign items': {
+    top: 'Social',
+    mid: 'Social Mid-Funnel Campaigns'
+  },
+  'meta - acquisition - mid funnel pm campaign items': {
+    top: 'Social',
+    mid: 'Social Mid-Funnel Campaigns'
+  },
+  'meta - remarketing - mid funnel pm campaign items': {
+    top: 'Social',
+    mid: 'Social Mid-Funnel Campaigns'
+  },
+  'youtube - acquisition - mid funnel pm campaign items': {
+    top: 'Social',
+    mid: 'Social Mid-Funnel Campaigns'
+  },
+  'tiktok - acquisition - mid funnel pm campaign items': {
+    top: 'Social',
+    mid: 'Social Mid-Funnel Campaigns'
+  },
+  'facebook prospecting - daba campaign items': {
+    top: 'Social',
+    mid: 'Social DABA'
+  },
+  'pinterest remarketing campaign items': {
+    top: 'Social',
+    mid: 'Social Retargeting'
+  },
+  'tiktok - remarketing campaign items': {
+    top: 'Social',
+    mid: 'Social Retargeting'
+  },
+  'tiktok remarketing campaign items': {
+    top: 'Social',
+    mid: 'Social Retargeting'
+  },
+  'facebook remarketing campaign items': {
+    top: 'Social',
+    mid: 'Social Retargeting'
+  },
+  'pinterest paid prospecting campaign items': {
+    top: 'Social',
+    mid: 'Social Performance Prospecting'
+  },
+  'facebook prospecting campaign items': {
+    top: 'Social',
+    mid: 'Social Performance Prospecting'
+  },
+  'tiktok - remarketing - mid funnel pm': {
+    top: 'Non-Paid',
+    mid: 'Other'
+  },
+  'misc/uncategorized campaign items': { top: 'Non-Paid', mid: 'Not Set' },
+  'not set / not set campaign items': { top: 'Non-Paid', mid: 'Not Set' },
+  'non-coupon affiliate(s) campaign items': {
+    top: 'Non-Paid',
+    mid: 'Affiliate'
+  },
+  'coupon affiliate(s) campaign items': { top: 'Non-Paid', mid: 'Affiliate' },
+  'organic non-brand campaign items': {
+    top: 'Non-Paid',
+    mid: 'Organic Search'
+  },
+  'organic brand campaign items': { top: 'Non-Paid', mid: 'Organic Search' },
+  'organic social campaign items': { top: 'Non-Paid', mid: 'Organic Social' },
+  'pinterest organic campaign items': {
+    top: 'Non-Paid',
+    mid: 'Organic Social'
+  },
+  'referral campaign items': { top: 'Non-Paid', mid: 'Referral' },
+  'email campaign items': { top: 'Non-Paid', mid: 'Email/SMS' },
+  'attentive - sms/text campaign items': {
+    top: 'Non-Paid',
+    mid: 'Email/SMS'
+  },
+  'direct campaign items': { top: 'Non-Paid', mid: 'Direct' },
+  'google non-brand shopping campaigns items': {
+    top: 'Shopping',
+    mid: 'NBR Shopping'
+  },
+  'microsoft non-brand shopping campaigns items': {
+    top: 'Shopping',
+    mid: 'NBR Shopping'
+  },
+  'google brand shopping campaigns items': {
+    top: 'Shopping',
+    mid: 'BR Shopping'
+  },
+  'microsoft brand shopping campaigns items': {
+    top: 'Shopping',
+    mid: 'BR Shopping'
+  },
+  'google non-brand text campaign items': {
+    top: 'Search',
+    mid: 'NBR Text'
+  },
+  'microsoft non-brand text campaign items': {
+    top: 'Search',
+    mid: 'NBR Text'
+  },
+  'google brand text campaign items': {
+    top: 'Search',
+    mid: 'BR Text'
+  },
+  'microsoft brand text campaign items': {
+    top: 'Search',
+    mid: 'BR Text'
+  },
+  'google demand gen campaign items': {
+    top: 'Display',
+    mid: 'Google Display Prospecting'
+  },
+  'google display ads campaign items': {
+    top: 'Display',
+    mid: 'Google Display Prospecting'
+  },
+  'youtube prospecting campaign items': {
+    top: 'Display',
+    mid: 'Google Display Prospecting'
+  },
+  'google display and video retargeting': {
+    top: 'Display',
+    mid: 'Google Display Remarketing'
+  }
+}
+
+const defaultTopClassification = (mapping: string): string => {
+  if (mapping.includes('shopping')) return 'Shopping'
+  if (mapping.includes('search')) return 'Search'
+  if (
+    mapping.includes('social') ||
+    mapping.includes('facebook') ||
+    mapping.includes('tiktok')
+  )
+    return 'Social'
+  if (mapping.includes('display') || mapping.includes('daba')) return 'Display'
+  if (
+    mapping.includes('organic') ||
+    mapping.includes('not set') ||
+    mapping.includes('affiliate')
+  )
+    return 'Non-Paid'
+  return 'Other'
+}
+
+const classifyInfo = (row: any): Classification => {
+  const mapping = (row.New_mapping || '').toLowerCase()
+  const found = classificationMap[mapping]
+  if (found) return found
+  return { top: defaultTopClassification(mapping), mid: 'Other' }
+}
+
+const classifyTopLevel = (row: any): string => classifyInfo(row).top
+const classifySecondLevel = (row: any): string => classifyInfo(row).mid
 
 export const CampaignTree = () => {
   const [data] = Retool.useStateObject({
@@ -52,14 +232,14 @@ export const CampaignTree = () => {
     label: 'Campaign Data',
     inspector: 'text',
     description: 'Nested campaign hierarchy'
-  });
+  })
 
   const [priorData] = Retool.useStateObject({
     name: 'priorData',
     label: 'Prior Data',
     inspector: 'text',
     description: 'Prior date range data'
-  });
+  })
 
   const [layout] = Retool.useStateArray({
     name: 'layout',
@@ -67,49 +247,45 @@ export const CampaignTree = () => {
     inspector: 'text',
     description:
       'JSON array of field names that defines the nesting order. Use "topClassification" for computed top level.',
-    initialValue: ['topClassification', 'New_mapping', 'Campaign_Nm']
-  });
+    initialValue: [
+      'topClassification',
+      'secondClassification',
+      'New_mapping',
+      'Campaign_Nm'
+    ]
+  })
 
-  const [expandedKeys, setExpandedKeys] = useState<Record<string, boolean>>({});
+  const [expandedKeys, setExpandedKeys] = useState<Record<string, boolean>>({})
 
   const toggleRow = (key: string) => {
-    setExpandedKeys(prev => ({
+    setExpandedKeys((prev) => ({
       ...prev,
       [key]: !prev[key]
-    }));
-  };
+    }))
+  }
 
   const columnToRow = (cols: Record<string, any>): any[] => {
-    if (!cols || typeof cols !== 'object') return [];
-    const keys = Object.keys(cols);
-    const length = cols[keys[0]]?.length || 0;
+    if (!cols || typeof cols !== 'object') return []
+    const keys = Object.keys(cols)
+    const length = cols[keys[0]]?.length || 0
     return Array.from({ length }, (_, i) => {
-      const row: Record<string, any> = {};
-      keys.forEach(k => (row[k] = cols[k][i]));
-      return row;
-    });
-  };
+      const row: Record<string, any> = {}
+      keys.forEach((k) => (row[k] = cols[k][i]))
+      return row
+    })
+  }
 
-  const classifyTopLevel = (row: any): string => {
-    const mapping = (row.New_mapping || '').toLowerCase();
-    if (mapping.includes('shopping')) return 'Shopping';
-    if (mapping.includes('search')) return 'Search';
-    if (mapping.includes('social') || mapping.includes('facebook') || mapping.includes('tiktok')) return 'Social';
-    if (mapping.includes('display') || mapping.includes('daba')) return 'Display';
-    if (mapping.includes('organic') || mapping.includes('not set') || mapping.includes('affiliate')) return 'Non-Paid';
-    return 'Other';
-  };
-
-  const rowsCurrent = columnToRow(data);
-  const rowsPrior = columnToRow(priorData);
-  const grouped: CampaignNode[] = [];
+  const rowsCurrent = columnToRow(data)
+  const rowsPrior = columnToRow(priorData)
+  const grouped: CampaignNode[] = []
 
   const addMetrics = (target: Metrics, row: any) => {
-    metricDefs.forEach(def => {
-      const val = row[def.key];
-      target[def.key] = (target[def.key] || 0) + (typeof val === 'number' ? val : 0);
-    });
-  };
+    metricDefs.forEach((def) => {
+      const val = row[def.key]
+      target[def.key] =
+        (target[def.key] || 0) + (typeof val === 'number' ? val : 0)
+    })
+  }
 
   const insertRow = (
     nodes: CampaignNode[],
@@ -118,147 +294,198 @@ export const CampaignTree = () => {
     keys: string[],
     isPrior: boolean
   ) => {
-    const key = keys[depth];
-    const value = key === 'topClassification' ? classifyTopLevel(row) : row[key] || '(Unnamed)';
+    const key = keys[depth]
+    const value =
+      key === 'topClassification'
+        ? classifyTopLevel(row)
+        : key === 'secondClassification'
+          ? classifySecondLevel(row)
+          : row[key] || '(Unnamed)'
 
-    let node = nodes.find(n => n.name === value);
+    let node = nodes.find((n) => n.name === value)
     if (!node) {
-      node = { name: value, current: {}, prior: {}, children: [] };
-      nodes.push(node);
+      node = { name: value, current: {}, prior: {}, children: [] }
+      nodes.push(node)
     }
 
-    addMetrics(isPrior ? node.prior : node.current, row);
+    addMetrics(isPrior ? node.prior : node.current, row)
 
     if (depth < keys.length - 1) {
-      insertRow(node.children!, row, depth + 1, keys, isPrior);
+      insertRow(node.children!, row, depth + 1, keys, isPrior)
     }
-  };
+  }
 
   const layoutKeys =
     Array.isArray(layout) && layout.length > 0
       ? (layout as string[])
-      : ['topClassification', 'New_mapping', 'Campaign_Nm'];
+      : [
+          'topClassification',
+          'secondClassification',
+          'New_mapping',
+          'Campaign_Nm'
+        ]
 
-  rowsCurrent.forEach(row => {
-    insertRow(grouped, row, 0, layoutKeys, false);
-  });
-  rowsPrior.forEach(row => {
-    insertRow(grouped, row, 0, layoutKeys, true);
-  });
+  rowsCurrent.forEach((row) => {
+    insertRow(grouped, row, 0, layoutKeys, false)
+  })
+  rowsPrior.forEach((row) => {
+    insertRow(grouped, row, 0, layoutKeys, true)
+  })
 
   const totals: { current: Metrics; prior: Metrics } = {
     current: {},
     prior: {}
-  };
-  grouped.forEach(node => {
-    metricDefs.forEach(def => {
+  }
+  grouped.forEach((node) => {
+    metricDefs.forEach((def) => {
       totals.current[def.key] =
-        (totals.current[def.key] || 0) + (node.current[def.key] || 0);
+        (totals.current[def.key] || 0) + (node.current[def.key] || 0)
       totals.prior[def.key] =
-        (totals.prior[def.key] || 0) + (node.prior[def.key] || 0);
-    });
-  });
+        (totals.prior[def.key] || 0) + (node.prior[def.key] || 0)
+    })
+  })
 
-  const formatNum = (num: number | undefined, digits: number, currency = false) => {
-    const value = num != null ? num : 0;
+  const formatNum = (
+    num: number | undefined,
+    digits: number,
+    currency = false
+  ) => {
+    const value = num != null ? num : 0
     const formatted = value.toLocaleString(undefined, {
       minimumFractionDigits: digits,
       maximumFractionDigits: digits
-    });
-    return currency ? `$${formatted}` : formatted;
-  };
+    })
+    return currency ? `$${formatted}` : formatted
+  }
 
   const pctChange = (curr?: number, prior?: number) => {
-    if (prior == null || prior === 0 || curr == null) return '';
-    return (((curr - prior) / prior) * 100).toFixed(2) + '%';
-  };
+    if (prior == null || prior === 0 || curr == null) return ''
+    return (((curr - prior) / prior) * 100).toFixed(2) + '%'
+  }
 
-  let rowCounter = 0;
+  let rowCounter = 0
 
-  const renderRows = (nodes: CampaignNode[], depth = 0, parentKey = ''): JSX.Element[] => {
+  const renderRows = (
+    nodes: CampaignNode[],
+    depth = 0,
+    parentKey = ''
+  ): JSX.Element[] => {
     return nodes.flatMap((node, index) => {
-      const key = `${parentKey}-${index}`;
-      const isExpanded = expandedKeys[key];
-      const hasChildren = Array.isArray(node.children) && node.children.length > 0;
+      const key = `${parentKey}-${index}`
+      const isExpanded = expandedKeys[key]
+      const hasChildren =
+        Array.isArray(node.children) && node.children.length > 0
 
-      const rowColor = rowCounter % 2 === 0 ? '#ffffff' : '#f2f2f2';
-      rowCounter++;
+      const rowColor = rowCounter % 2 === 0 ? '#ffffff' : '#f2f2f2'
+      rowCounter++
 
       return [
         <tr
           key={key}
-          style={{ fontWeight: hasChildren ? 'bold' : 'normal', background: rowColor }}
+          style={{
+            fontWeight: hasChildren ? 'bold' : 'normal',
+            background: rowColor
+          }}
         >
           <td style={{ padding: '4px 8px', minWidth: '240px' }}>
-            <div style={{ display: 'flex', alignItems: 'center', paddingLeft: `${depth * 24}px` }}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                paddingLeft: `${depth * 24}px`
+              }}
+            >
               {hasChildren && (
-                <button onClick={() => toggleRow(key)} style={{ marginRight: '6px' }}>
+                <button
+                  onClick={() => toggleRow(key)}
+                  style={{ marginRight: '6px' }}
+                >
                   {isExpanded ? '▾' : '▸'}
                 </button>
               )}
               <span>{node.name}</span>
             </div>
           </td>
-          {metricDefs.flatMap(def => {
-            const curr = node.current[def.key];
-            const prior = node.prior[def.key];
+          {metricDefs.flatMap((def) => {
+            const curr = node.current[def.key]
+            const prior = node.prior[def.key]
             return [
-              <td key={`${key}-${def.key}`} style={{ padding: '4px 8px' }}>{formatNum(curr, def.digits, def.currency)}</td>,
-              <td key={`${key}-${def.key}-p`} style={{ padding: '4px 8px' }}>{formatNum(prior, def.digits, def.currency)}</td>,
-              <td key={`${key}-${def.key}-c`} style={{ padding: '4px 8px' }}>{pctChange(curr, prior)}</td>
-            ];
+              <td key={`${key}-${def.key}`} style={{ padding: '4px 8px' }}>
+                {formatNum(curr, def.digits, def.currency)}
+              </td>,
+              <td key={`${key}-${def.key}-p`} style={{ padding: '4px 8px' }}>
+                {formatNum(prior, def.digits, def.currency)}
+              </td>,
+              <td key={`${key}-${def.key}-c`} style={{ padding: '4px 8px' }}>
+                {pctChange(curr, prior)}
+              </td>
+            ]
           })}
         </tr>,
-        ...(isExpanded && hasChildren ? renderRows(node.children!, depth + 1, key) : [])
-      ];
-    });
-  };
+        ...(isExpanded && hasChildren
+          ? renderRows(node.children!, depth + 1, key)
+          : [])
+      ]
+    })
+  }
 
   return (
     <div style={{ fontFamily: 'sans-serif', padding: '12px' }}>
       <div style={{ overflowX: 'auto' }}>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: '14px'
+          }}
+        >
           <thead>
             <tr style={{ textAlign: 'left', borderBottom: '2px solid #ccc' }}>
               <th style={{ padding: '4px 8px', minWidth: '240px' }}>Name</th>
-            {metricDefs.flatMap(def => [
-              <th key={def.key} style={{ padding: '4px 8px' }}>{def.label}</th>,
-              <th key={def.key + '-p'} style={{ padding: '4px 8px' }}>{def.label} Prior</th>,
-              <th key={def.key + '-c'} style={{ padding: '4px 8px' }}>% Change</th>
-            ])}
-          </tr>
-        </thead>
-        <tbody>{renderRows(grouped)}</tbody>
-        <tfoot>
-          <tr
-            style={{
-              fontWeight: 'bold',
-              borderTop: '2px solid #ccc',
-              background: rowCounter % 2 === 0 ? '#ffffff' : '#f2f2f2'
-            }}
-          >
-            <td style={{ padding: '4px 8px' }}>Grand Total</td>
-            {metricDefs.flatMap(def => {
-              const curr = totals.current[def.key];
-              const prior = totals.prior[def.key];
-              return [
-                <td key={`total-${def.key}`} style={{ padding: '4px 8px' }}>
-                  {formatNum(curr, def.digits, def.currency)}
-                </td>,
-                <td key={`total-${def.key}-p`} style={{ padding: '4px 8px' }}>
-                  {formatNum(prior, def.digits, def.currency)}
-                </td>,
-                <td key={`total-${def.key}-c`} style={{ padding: '4px 8px' }}>
-                  {pctChange(curr, prior)}
-                </td>
-              ];
-            })}
-          </tr>
-        </tfoot>
+              {metricDefs.flatMap((def) => [
+                <th key={def.key} style={{ padding: '4px 8px' }}>
+                  {def.label}
+                </th>,
+                <th key={def.key + '-p'} style={{ padding: '4px 8px' }}>
+                  {def.label} Prior
+                </th>,
+                <th key={def.key + '-c'} style={{ padding: '4px 8px' }}>
+                  % Change
+                </th>
+              ])}
+            </tr>
+          </thead>
+          <tbody>{renderRows(grouped)}</tbody>
+          <tfoot>
+            <tr
+              style={{
+                fontWeight: 'bold',
+                borderTop: '2px solid #ccc',
+                background: rowCounter % 2 === 0 ? '#ffffff' : '#f2f2f2'
+              }}
+            >
+              <td style={{ padding: '4px 8px' }}>Grand Total</td>
+              {metricDefs.flatMap((def) => {
+                const curr = totals.current[def.key]
+                const prior = totals.prior[def.key]
+                return [
+                  <td key={`total-${def.key}`} style={{ padding: '4px 8px' }}>
+                    {formatNum(curr, def.digits, def.currency)}
+                  </td>,
+                  <td key={`total-${def.key}-p`} style={{ padding: '4px 8px' }}>
+                    {formatNum(prior, def.digits, def.currency)}
+                  </td>,
+                  <td key={`total-${def.key}-c`} style={{ padding: '4px 8px' }}>
+                    {pctChange(curr, prior)}
+                  </td>
+                ]
+              })}
+            </tr>
+          </tfoot>
         </table>
       </div>
     </div>
-  );
-};
+  )
+}
 
-export default CampaignTree;
+export default CampaignTree


### PR DESCRIPTION
## Summary
- map campaign items to their appropriate categories
- support second-level classification and default layout

## Testing
- `npx prettier -w src/index.tsx`
- `npx tsc --noEmit`
- `npx eslint src`


------
https://chatgpt.com/codex/tasks/task_e_6849df5f92788332a1a8e6b32c89bd04