### PR TITLE
Remove unnamed dropdown level

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -302,16 +302,24 @@ export const CampaignTree = () => {
     isPrior: boolean
   ) => {
     const key = keys[depth]
-    const value =
+    const rawValue =
       key === 'topClassification'
         ? classifyTopLevel(row)
         : key === 'secondClassification'
           ? classifySecondLevel(row)
-          : row[key] || '(Unnamed)'
+          : row[key]
 
-    let node = nodes.find((n) => n.name === value)
+    if (!rawValue || rawValue === '(Unnamed)') {
+      if (depth < keys.length - 1) {
+        // Skip unnamed levels and attach children directly to the parent
+        insertRow(nodes, row, depth + 1, keys, isPrior)
+      }
+      return
+    }
+
+    let node = nodes.find((n) => n.name === rawValue)
     if (!node) {
-      node = { name: value, current: {}, prior: {}, children: [] }
+      node = { name: rawValue, current: {}, prior: {}, children: [] }
       nodes.push(node)
     }
 


### PR DESCRIPTION
## Summary
- skip unnamed rows when building nested campaign hierarchy

## Testing
- `npx tsc`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4915ddc83329eab0387679d477a