### PR TITLE
Reclassify Email/SMS rows as marketing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -141,9 +141,9 @@ const classificationMap: Record<string, Classification> = {
     mid: 'Organic Social'
   },
   'referral': { top: 'Non-Paid', mid: 'Referral' },
-  'email': { top: 'Non-Paid', mid: 'Email/SMS' },
+  'email': { top: 'Non-Paid Email/SMS', mid: 'Email/SMS' },
   'attentive - sms/text': {
-    top: 'Non-Paid',
+    top: 'Non-Paid Email/SMS',
     mid: 'Email/SMS'
   },
   'direct': { top: 'Non-Paid', mid: 'Direct' },
@@ -207,6 +207,8 @@ const defaultTopClassification = (mapping: string): string => {
   )
     return 'Social'
   if (mapping.includes('display') || mapping.includes('daba')) return 'Display'
+  if (mapping.includes('email') || mapping.includes('sms'))
+    return 'Non-Paid Email/SMS'
   if (
     mapping.includes('organic') ||
     mapping.includes('not set') ||


### PR DESCRIPTION
## Summary
- update classification map so Email/SMS appears as part of marketing
- tweak default classification logic to detect email/sms rows

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6849f052e38083328e024b65624f48d9